### PR TITLE
Fix Reload of imaging orders after picking

### DIFF
--- a/packages/esm-imaging-orders-app/src/form/review-form/review-imaging-form.workspace.tsx
+++ b/packages/esm-imaging-orders-app/src/form/review-form/review-imaging-form.workspace.tsx
@@ -72,16 +72,20 @@ const ImagingReviewForm: React.FC<ReviewOrderDialogProps> = ({ order, closeWorks
     setIsSubmitting(true);
 
     try {
-      await updateImagingProcedure(order?.procedures[0]?.uuid, { outcome: 'SUCCESSFUL' });
-      showSnackbar({
-        isLowContrast: true,
-        title: t('createResponse', 'Create Review'),
-        kind: 'success',
-        subtitle: t('pickSuccessfully', 'You have successfully created a review'),
+      const response = await updateImagingProcedure(order?.procedures[0]?.uuid, {
+        outcome: 'SUCCESSFUL',
       });
-      closeWorkspace();
-      mutate((key) => typeof key === 'string' && key.startsWith('/ws/rest/v1/procedure'));
-      mutate((key) => typeof key === 'string' && key.startsWith('/ws/rest/v1/order'));
+      if (response.ok) {
+        showSnackbar({
+          isLowContrast: true,
+          title: t('createResponse', 'Create Review'),
+          kind: 'success',
+          subtitle: t('pickSuccessfully', 'You have successfully created a review'),
+        });
+        closeWorkspace();
+        mutate((key) => typeof key === 'string' && key.startsWith('/ws/rest/v1/procedure'));
+        mutate((key) => typeof key === 'string' && key.startsWith('/ws/rest/v1/order'));
+      }
     } catch (error: any) {
       showNotification({
         title: t('errorPicking', 'Error Creating Review'),

--- a/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/pick-imaging-order/add-to-worklist-dialog.component.tsx
+++ b/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/pick-imaging-order/add-to-worklist-dialog.component.tsx
@@ -37,8 +37,10 @@ const AddImagingToWorkListModal: React.FC<AddImagingToWorkListModalProps> = ({ o
           kind: 'success',
           subtitle: t('pickSuccessfully', 'You have successfully picked an Order'),
         });
-
         closeModal();
+        mutate((key) => typeof key === 'string' && key.startsWith('/ws/rest/v1/order'), undefined, {
+          revalidate: true,
+        });
       }
     } catch (error) {
       showNotification({

--- a/packages/esm-procedure-orders-app/src/header/procedure-header.component.tsx
+++ b/packages/esm-procedure-orders-app/src/header/procedure-header.component.tsx
@@ -15,7 +15,7 @@ export const ProcedureHeader: React.FC = () => {
       <div className={styles['left-justified-items']}>
         <ProcedureIllustration />
         <div className={styles['page-labels']}>
-          <p className={styles['page-name']}>{t('procedure', 'Procedures')}</p>
+          <p className={styles['page-name']}>{t('procedure_orders', 'Procedure Orders')}</p>
         </div>
       </div>
       <div className={styles['right-justified-items']}>


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
- [ ] Fix reloading of imaging orders after being picked
- [ ] Rename procedures page header to procedure orders
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
